### PR TITLE
Issue8

### DIFF
--- a/BoatReservation/forms.py
+++ b/BoatReservation/forms.py
@@ -38,10 +38,10 @@ class ReservationForm(forms.ModelForm):
     def clean(self):
         if(len(self.errors) == 0):  #skip form validation if field validation found errors
             self.validateEndTimeAfterStartTime()
-            self.validateNotOverlapping()
-            self.validateInAcceptableDateRange()
-            self.validateAcceptableLength()
             self.validateInFuture()
+            self.validateAcceptableLength()
+            self.validateInAcceptableDateRange()
+            self.validateNotOverlapping()
         return self.cleaned_data
 
     def validateNotOverlapping(self):

--- a/BoatReservation/forms.py
+++ b/BoatReservation/forms.py
@@ -59,6 +59,7 @@ class ReservationForm(forms.ModelForm):
         '''
         Reservations can't start before 9:00 am and can't end after 6:00pm
         raises ValidationError if the start or end time is outside the acceptable range.
+        TODO: this should be field-level validation rather than form-level (shouldn't affect functionality)
         :return:
         '''
         if self.cleaned_data.get("start_time").hour < 9:
@@ -91,6 +92,7 @@ class ReservationForm(forms.ModelForm):
         '''
         Raises ValidationError if the reservation start time is before datetime.now()
         This is done in the front-end but it's best to do it back here too
+        TODO: this should be field-level validation rather than form-level (shouldn't affect functionality)
         :return:
         '''
         if(self.cleaned_data.get("start_time") < datetime.now()):

--- a/BoatReservation/forms.py
+++ b/BoatReservation/forms.py
@@ -1,10 +1,10 @@
-from django.core.exceptions import ValidationError
-
 __author__ = 'dbannon'
 
 from django import forms
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
+from django.core.exceptions import ValidationError
+from datetime import timedelta, datetime
 
 from .models import Reservation
 
@@ -36,8 +36,62 @@ class ReservationForm(forms.ModelForm):
 
     def clean(self):
         if(len(self.errors) == 0):  #skip form validation if field validation found errors
-            overlappingReservations = Reservation.objects.exclude(end_time__lte=self.cleaned_data.get('start_time')).exclude(start_time__gte=self.cleaned_data.get('end_time'))
-            for r in overlappingReservations:
-                if(r.boat == self.cleaned_data.get('boat')):
-                    raise ValidationError( 'This boat is already reserved for this time slot', code="alreadyReserved")
+            self.validateEndTimeAfterStartTime()
+            self.validateNotOverlapping()
+            self.validateInAcceptableDateRange()
+            self.validateAcceptableLength()
+            self.validateInFuture()
         return self.cleaned_data
+
+    def validateNotOverlapping(self):
+        '''
+        This reservation can't conflict with a previously created reservation
+        times can overlap, as long as the reserved boat isn't also the same
+        returns nothing, raises ValidationError if it overlaps
+        :return:
+        '''
+        overlappingReservations = Reservation.objects.exclude(end_time__lte=self.cleaned_data.get('start_time')).exclude(start_time__gte=self.cleaned_data.get('end_time'))
+        for r in overlappingReservations:
+            if(r.boat == self.cleaned_data.get('boat')):
+                raise ValidationError( 'This boat is already reserved for this time slot', code="alreadyReserved")
+
+    def validateInAcceptableDateRange(self):
+        '''
+        Reservations can't start before 9:00 am and can't end after 6:00pm
+        raises ValidationError if the start or end time is outside the acceptable range.
+        :return:
+        '''
+        if self.cleaned_data.get("start_time").hour < 9:
+            raise ValidationError("Your reservation cannot start before 9:00 AM")
+        end_time = self.cleaned_data.get("end_time")
+        if (end_time > datetime(end_time.year, end_time.month, end_time.day, 18)):
+            raise ValidationError("Your reservation cannot end after 6:00 PM")
+
+    def validateAcceptableLength(self):
+        '''
+        Raises ValidationError if the reservation is less than 30 min long or more than 4 hours
+        :return:
+        '''
+        length = self.cleaned_data.get("end_time") - self.cleaned_data.get("start_time")
+        if(length < timedelta(0, 60*30)):
+            raise ValidationError('Reservations cannot be less than 30 minutes long', code="tooShort")
+        elif (length > timedelta(0, 60*60*4)):
+            raise ValidationError('Reservations cannot be more than 4 hours long', code="tooLong")
+
+    def validateEndTimeAfterStartTime(self):
+        '''
+        Raises ValidationError if the reservation end time is before or equal to the start time
+        I think this is done in the front-end but it's best to do it back here too
+        :return:
+        '''
+        if(self.cleaned_data.get("end_time") <= self.cleaned_data.get("start_time")):
+            raise ValidationError('Reservations cannot end before they start', code="wrongDirection")
+
+    def validateInFuture(self):
+        '''
+        Raises ValidationError if the reservation start time is before datetime.now()
+        This is done in the front-end but it's best to do it back here too
+        :return:
+        '''
+        if(self.cleaned_data.get("start_time") < datetime.now()):
+            raise ValidationError('Reservations cannot start in the past', code="spaceTimeContinuum")

--- a/BoatReservation/forms.py
+++ b/BoatReservation/forms.py
@@ -4,6 +4,7 @@ from django import forms
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 from datetime import timedelta, datetime
 
 from .models import Reservation
@@ -96,5 +97,5 @@ class ReservationForm(forms.ModelForm):
         TODO: this should be field-level validation rather than form-level (shouldn't affect functionality)
         :return:
         '''
-        if(self.cleaned_data.get("start_time") < datetime.now()):
+        if(self.cleaned_data.get("start_time") < timezone.now()):
             raise ValidationError('Reservations cannot start in the past', code="spaceTimeContinuum")

--- a/BoatReservation/forms.py
+++ b/BoatReservation/forms.py
@@ -65,7 +65,8 @@ class ReservationForm(forms.ModelForm):
         if self.cleaned_data.get("start_time").hour < 9:
             raise ValidationError("Your reservation cannot start before 9:00 AM")
         end_time = self.cleaned_data.get("end_time")
-        if (end_time > datetime(end_time.year, end_time.month, end_time.day, 18)):
+        if ((end_time.hour == 18 and end_time.minute > 0) or end_time.hour > 18):
+            #this condition is "good enough", not perfect. Should really compare to another datetime, but that's complicated
             raise ValidationError("Your reservation cannot end after 6:00 PM")
 
     def validateAcceptableLength(self):
@@ -81,11 +82,11 @@ class ReservationForm(forms.ModelForm):
 
     def validateEndTimeAfterStartTime(self):
         '''
-        Raises ValidationError if the reservation end time is before or equal to the start time
+        Raises ValidationError if the reservation end time is before the start time
         I think this is done in the front-end but it's best to do it back here too
         :return:
         '''
-        if(self.cleaned_data.get("end_time") <= self.cleaned_data.get("start_time")):
+        if(self.cleaned_data.get("end_time") < self.cleaned_data.get("start_time")):
             raise ValidationError('Reservations cannot end before they start', code="wrongDirection")
 
     def validateInFuture(self):


### PR DESCRIPTION
Added more validation to the reservation start/end time

Added validations:
-reservation starts after 9am and ends before 6pm
-reservation is more than 30min and less than 4hr
-reservation ends after it starts
-reservation doesn't start in the past

The values used seemed like sensible defaults to me, but feel free to change them.

Linked issue: https://github.com/dylanrb123/RitCrew/issues/8
